### PR TITLE
Add function to allow minimal amount of samples that reach the requiered coverage

### DIFF
--- a/libs/hydi.c
+++ b/libs/hydi.c
@@ -1347,7 +1347,7 @@ void hydi_iter(FILE *dev, char* fn1, char* fn2, uint32_t minrep,
       hydi_counts_t tab2;
 
       hydi_parse(str1, len1, &tab1, nsamp1, count);
-      hydi_parse(str2, len2, &tab2, nsamp1, count);
+      hydi_parse(str2, len2, &tab2, nsamp2, count);
  
       overshoot = hydi_overshoot(&p_A1[count-1], alpha);
       hmC = hydi_hmC(&p_A1[count-1], alpha);


### PR DESCRIPTION
I added the function where you can select via -m (default 3) how much samples in both groups have to reach the required coverage. All dots or counts lower or equal the select coverage (via -c, default 10) are substituted by an NA. If to much samples per group do not have the required coverage the CG is ignored in both groups.